### PR TITLE
fix: change rewritten function name`traced` to `__apm$traced`

### DIFF
--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -103,13 +103,13 @@ impl Instrumentation {
         ));
 
         body.stmts = vec![
-            quote!("const traced = $traced;" as Stmt, traced: Expr = traced_fn.into()),
+            quote!("const __apm$traced = $traced;" as Stmt, traced: Expr = traced_fn.into()),
             quote!(
-                "if (!$ch.hasSubscribers) return traced();" as Stmt,
+                "if (!$ch.hasSubscribers) return __apm$traced();" as Stmt,
                 ch = ch_ident
             ),
             quote!(
-                "return $trace(traced, { arguments, self: this } );" as Stmt,
+                "return $trace(__apm$traced, { arguments, self: this } );" as Stmt,
                 trace = trace_ident
             ),
         ];


### PR DESCRIPTION
This change the function name that wraps original code from `traced` to `__apm$traced`, to avoid colliding with original argument names. See issue https://github.com/DataDog/orchestrion-js/issues/18 for repro and stuff.

I felt silly adding a test for this like so, because it woudl only test a specific argument name, so I did not write it:
```javascript
function test (traced) {
  console.log(traced)
}
```

Closes https://github.com/DataDog/orchestrion-js/issues/18