### PR TITLE
convert ArrowFunctionExpression to FunctionExpression in traceFunction

### DIFF
--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -114,6 +114,13 @@ function traceAny (state, node, _parent, ancestry) {
 function traceFunction (state, node, program) {
   transforms.tracingChannelDeclaration(state, program)
 
+  // Arrow functions have no own `arguments` or `this` binding. Converting to
+  // a regular FunctionExpression gives the wrapper its own `arguments` (the
+  // actual call arguments) and a dynamic `this` (the receiver at call time).
+  if (node.type === 'ArrowFunctionExpression') {
+    node.type = 'FunctionExpression'
+  }
+
   const { functionQuery: { methodName, privateMethodName, functionName, expressionName } } = state
   const isConstructor = methodName === 'constructor' ||
     (!methodName && !privateMethodName && !functionName && !expressionName)

--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -114,11 +114,13 @@ function traceAny (state, node, _parent, ancestry) {
 function traceFunction (state, node, program) {
   transforms.tracingChannelDeclaration(state, program)
 
-  // Arrow functions have no own `arguments` or `this` binding. Converting to
-  // a regular FunctionExpression gives the wrapper its own `arguments` (the
-  // actual call arguments) and a dynamic `this` (the receiver at call time).
+  // Arrow functions have no own `arguments` or `this` binding. Replace params
+  // with a rest element so the wrapper captures call-site arguments in
+  // __apm$args. The original params are preserved for the inner __apm$wrapped
+  // function so the original body's parameter names remain valid.
+  const originalParams = node.params
   if (node.type === 'ArrowFunctionExpression') {
-    node.type = 'FunctionExpression'
+    node.params = [{ type: 'RestElement', argument: { type: 'Identifier', name: '__apm$args' } }]
   }
 
   const { functionQuery: { methodName, privateMethodName, functionName, expressionName } } = state
@@ -128,11 +130,12 @@ function traceFunction (state, node, program) {
 
   node.body = wrap(state, {
     type,
-    params: node.params,
+    params: originalParams,
     body: node.body,
     async: node.async,
     expression: false,
     generator: node.generator,
+    outerIsArrow: node.type === 'ArrowFunctionExpression',
   }, program)
 
   // The original function no longer contains any calls to `await` or `yield` as
@@ -225,8 +228,20 @@ function wrap (state, node, program) {
   if (operator === 'traceSync') wrapper = wrapSync(state, node, program)
 
   const block = wrapper.body[0].body // Extract only block statement of function body.
-  const common = parse(node.type === 'ArrowFunctionExpression'
+  const common = parse(node.outerIsArrow
     ? `
+    const __apm$ctx = {
+      arguments: __apm$args,
+      self: this,
+      moduleVersion: ${JSON.stringify(moduleVersion)}
+    };
+    const __apm$traced = () => {
+      const __apm$wrapped = () => {};
+      return __apm$wrapped.apply(this, __apm$args);
+    };
+  `
+    : node.type === 'ArrowFunctionExpression'
+      ? `
     const __apm$ctx = {
       arguments,
       moduleVersion: ${JSON.stringify(moduleVersion)}
@@ -236,7 +251,7 @@ function wrap (state, node, program) {
       return __apm$wrapped(...arguments);
     };
   `
-    : `
+      : `
     const __apm$ctx = {
       arguments,
       self: this,

--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -82,6 +82,22 @@ const transforms = module.exports = {
   traceSync: traceAny,
 }
 
+function wrapParams (params) {
+  // Replace params with numbered placeholders (__apm$arg0, __apm$arg1, ...) plus
+  // a rest element (...__apm$args) to capture overflow. This preserves .length
+  // while giving the preamble a uniform way to reconstruct all call-site
+  // arguments. The original params are passed to the inner __apm$wrapped function
+  // so the original body's parameter names remain valid.
+  const originalParams = params || []
+  const numberedParams = originalParams
+    .filter(param => param.type !== 'RestElement' && param.type !== 'AssignmentPattern')
+    .map((_, i) => ({ type: 'Identifier', name: `__apm$arg${i}` }))
+
+  return [
+    ...numberedParams,
+    { type: 'RestElement', argument: { type: 'Identifier', name: '__apm$args' } }
+  ]
+}
 /**
  * Generic trace entry point. Dispatches to {@link traceInstanceMethod} for class
  * nodes or {@link traceFunction} for all other function nodes.
@@ -118,30 +134,18 @@ function traceFunction (state, node, program) {
   const isConstructor = methodName === 'constructor' ||
   (!methodName && !privateMethodName && !functionName && !expressionName)
   const type = isConstructor ? 'ArrowFunctionExpression' : 'FunctionExpression'
-
-  // Replace params with numbered placeholders (__apm$arg0, __apm$arg1, ...) plus
-  // a rest element (...__apm$args) to capture overflow. This preserves .length
-  // while giving the preamble a uniform way to reconstruct all call-site
-  // arguments. The original params are passed to the inner __apm$wrapped function
-  // so the original body's parameter names remain valid.
-  const originalParams = node.params || []
-  const numberedParams = originalParams
-    .filter(param => param.type !== 'RestElement' && param.type !== 'AssignmentPattern')
-    .map((_, i) => ({ type: 'Identifier', name: `__apm$arg${i}` }))
+  const params = node.params
 
   node.body = wrap(state, {
     type,
-    params: originalParams,
+    params,
     body: node.body,
     async: node.async,
     expression: false,
     generator: node.generator,
   }, program)
 
-  node.params = [
-    ...numberedParams,
-    { type: 'RestElement', argument: { type: 'Identifier', name: '__apm$args' } }
-  ]
+  node.params = wrapParams(params)
 
   // The original function no longer contains any calls to `await` or `yield` as
   // the function body is copied to the internal wrapped function, so we set
@@ -198,6 +202,12 @@ function traceInstanceMethod (state, node, program) {
   const ctorBody = parse(`
     const __apm$${methodName} = this["${methodName}"]
     this["${methodName}"] = function () {}
+    if (typeof __apm$${methodName} === 'function') {
+      Object.defineProperty(this["${methodName}"], 'length', { 
+        value: __apm$${methodName}.length,
+        configurable: true
+      })
+    }
   `).body
 
   // Extract only right-hand side function of line 2.

--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -232,7 +232,7 @@ function wrap (state, node, program) {
   if (operator === 'tracePromise') wrapper = wrapPromise(state, node, program)
   if (operator === 'traceSync') wrapper = wrapSync(state, node, program)
 
-  const args = node.params
+  const args = (node.params || [])
     .filter(param => param.type !== 'RestElement' && param.type !== 'AssignmentPattern')
     .map((_, i) => `__apm$arg${i}`).concat('...__apm$args').join(', ')
 

--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -114,19 +114,20 @@ function traceAny (state, node, _parent, ancestry) {
 function traceFunction (state, node, program) {
   transforms.tracingChannelDeclaration(state, program)
 
-  // Arrow functions have no own `arguments` or `this` binding. Replace params
-  // with a rest element so the wrapper captures call-site arguments in
-  // __apm$args. The original params are preserved for the inner __apm$wrapped
-  // function so the original body's parameter names remain valid.
-  const originalParams = node.params
-  if (node.type === 'ArrowFunctionExpression') {
-    node.params = [{ type: 'RestElement', argument: { type: 'Identifier', name: '__apm$args' } }]
-  }
-
   const { functionQuery: { methodName, privateMethodName, functionName, expressionName } } = state
   const isConstructor = methodName === 'constructor' ||
-    (!methodName && !privateMethodName && !functionName && !expressionName)
+  (!methodName && !privateMethodName && !functionName && !expressionName)
   const type = isConstructor ? 'ArrowFunctionExpression' : 'FunctionExpression'
+
+  // Replace params with numbered placeholders (__apm$arg0, __apm$arg1, ...) plus
+  // a rest element (...__apm$args) to capture overflow. This preserves .length
+  // while giving the preamble a uniform way to reconstruct all call-site
+  // arguments. The original params are passed to the inner __apm$wrapped function
+  // so the original body's parameter names remain valid.
+  const originalParams = node.params || []
+  const numberedParams = originalParams
+    .filter(param => param.type !== 'RestElement' && param.type !== 'AssignmentPattern')
+    .map((_, i) => ({ type: 'Identifier', name: `__apm$arg${i}` }))
 
   node.body = wrap(state, {
     type,
@@ -135,8 +136,12 @@ function traceFunction (state, node, program) {
     async: node.async,
     expression: false,
     generator: node.generator,
-    outerIsArrow: node.type === 'ArrowFunctionExpression',
   }, program)
+
+  node.params = [
+    ...numberedParams,
+    { type: 'RestElement', argument: { type: 'Identifier', name: '__apm$args' } }
+  ]
 
   // The original function no longer contains any calls to `await` or `yield` as
   // the function body is copied to the internal wrapped function, so we set
@@ -197,10 +202,10 @@ function traceInstanceMethod (state, node, program) {
 
   // Extract only right-hand side function of line 2.
   const fn = ctorBody[1].expression.right
+  fn.params = [{ type: 'RestElement', argument: { type: 'Identifier', name: '__apm$args' } }]
 
   fn.async = operator === 'tracePromise'
   fn.body = wrap(state, { type: 'Identifier', name: `__apm$${methodName}` }, program)
-
   wrapSuper(state, fn)
 
   ctor.value.body.body.push(...ctorBody)
@@ -227,39 +232,33 @@ function wrap (state, node, program) {
   if (operator === 'tracePromise') wrapper = wrapPromise(state, node, program)
   if (operator === 'traceSync') wrapper = wrapSync(state, node, program)
 
+  const args = node.params
+    .filter(param => param.type !== 'RestElement' && param.type !== 'AssignmentPattern')
+    .map((_, i) => `__apm$arg${i}`).concat('...__apm$args').join(', ')
+
   const block = wrapper.body[0].body // Extract only block statement of function body.
-  const common = parse(node.outerIsArrow
+  const common = parse(node.type === 'ArrowFunctionExpression'
     ? `
+    const __apm$arguments = [${args}];
     const __apm$ctx = {
-      arguments: __apm$args,
+      arguments: __apm$arguments,
+      moduleVersion: ${JSON.stringify(moduleVersion)}
+    };
+    const __apm$traced = () => {
+      const __apm$wrapped = () => {};
+      return __apm$wrapped(...__apm$arguments);
+    };
+  `
+    : `
+    const __apm$arguments = [${args}];
+    const __apm$ctx = {
+      arguments: __apm$arguments,
       self: this,
       moduleVersion: ${JSON.stringify(moduleVersion)}
     };
     const __apm$traced = () => {
       const __apm$wrapped = () => {};
-      return __apm$wrapped.apply(this, __apm$args);
-    };
-  `
-    : node.type === 'ArrowFunctionExpression'
-      ? `
-    const __apm$ctx = {
-      arguments,
-      moduleVersion: ${JSON.stringify(moduleVersion)}
-    };
-    const __apm$traced = () => {
-      const __apm$wrapped = () => {};
-      return __apm$wrapped(...arguments);
-    };
-  `
-      : `
-    const __apm$ctx = {
-      arguments,
-      self: this,
-      moduleVersion: ${JSON.stringify(moduleVersion)}
-    };
-    const __apm$traced = () => {
-      const __apm$wrapped = () => {};
-      return __apm$wrapped.apply(this, arguments);
+      return __apm$wrapped.apply(this, __apm$arguments);
     };
   `).body
 
@@ -347,7 +346,7 @@ function wrapCallback (state, node) {
 
   return parse(`
     function wrapper () {
-      const __apm$cb = Array.prototype.at.call(arguments, ${callbackIndex});
+      const __apm$cb = Array.prototype.at.call(__apm$arguments, ${callbackIndex});
 
       if (!${channelVariable}.start.hasSubscribers) return __apm$traced();
 
@@ -373,7 +372,7 @@ function wrapCallback (state, node) {
       if (typeof __apm$cb !== 'function') {
         return __apm$traced();
       }
-      Array.prototype.splice.call(arguments, ${callbackIndex}, 1, __apm$wrappedCb);
+      Array.prototype.splice.call(__apm$arguments, ${callbackIndex}, 1, __apm$wrappedCb);
 
       return ${channelVariable}.start.runStores(__apm$ctx, () => {
         try {

--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -82,12 +82,18 @@ const transforms = module.exports = {
   traceSync: traceAny,
 }
 
+/**
+ * Replaces a function's params with numbered placeholders (`__apm$arg0`,
+ * `__apm$arg1`, ...) plus a rest element (`...__apm$args`) to capture overflow.
+ * This preserves the function's `.length` while giving the preamble a uniform
+ * way to reconstruct all call-site arguments. `RestElement` and
+ * `AssignmentPattern` params are excluded from the count since they do not
+ * contribute to `.length`.
+ *
+ * @param {import('estree').Pattern[]} params - The original function params.
+ * @returns {import('estree').Pattern[]} The replacement params.
+ */
 function wrapParams (params) {
-  // Replace params with numbered placeholders (__apm$arg0, __apm$arg1, ...) plus
-  // a rest element (...__apm$args) to capture overflow. This preserves .length
-  // while giving the preamble a uniform way to reconstruct all call-site
-  // arguments. The original params are passed to the inner __apm$wrapped function
-  // so the original body's parameter names remain valid.
   const originalParams = params || []
   const numberedParams = originalParams
     .filter(param => param.type !== 'RestElement' && param.type !== 'AssignmentPattern')

--- a/tests/arrow_expr_args_cjs/mod.js
+++ b/tests/arrow_expr_args_cjs/mod.js
@@ -1,0 +1,8 @@
+'use strict'
+
+// Arrow function targeted via expressionName. Without the ArrowFunctionExpression
+// → FunctionExpression conversion, `arguments` inside the wrapper resolves to the
+// CJS module wrapper arguments instead of the actual call-site arguments.
+exports.fetch = async (url) => {
+  return url
+}

--- a/tests/arrow_expr_args_cjs/test.js
+++ b/tests/arrow_expr_args_cjs/test.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { fetch } = require('./instrumented.js')
+const { assert, getContext } = require('../common/preamble.js')
+const context = getContext('orchestrion:undici:fetch_arrow_args')
+
+// Without the ArrowFunctionExpression → FunctionExpression fix, `url` would
+// resolve to the CJS module wrapper arguments rather than 'https://example.com'.
+;(async () => {
+  const result = await fetch('https://example.com')
+  assert.strictEqual(result, 'https://example.com')
+  assert.deepStrictEqual(context, {
+    start: true,
+    end: true,
+    asyncStart: 'https://example.com',
+    asyncEnd: 'https://example.com'
+  })
+})()

--- a/tests/arrow_this_binding_cjs/mod.js
+++ b/tests/arrow_this_binding_cjs/mod.js
@@ -1,0 +1,12 @@
+'use strict'
+
+// Verifies that lexical `this` and call-site arguments are both preserved
+// correctly when an arrow function assigned to `this` is wrapped.
+function Connection (opts) {
+  this.prefix = 'result:'
+  this._query = async (sql) => {
+    return this.prefix + sql
+  }
+}
+
+module.exports = { Connection }

--- a/tests/arrow_this_binding_cjs/test.js
+++ b/tests/arrow_this_binding_cjs/test.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const { Connection } = require('./instrumented.js')
+const { assert, getContext } = require('../common/preamble.js')
+const context = getContext('orchestrion:undici:Connection_query_this')
+
+;(async () => {
+  const conn = new Connection({ host: 'localhost' })
+  const result = await conn._query('SELECT 1')
+  assert.strictEqual(result, 'result:SELECT 1')
+  assert.deepStrictEqual(context, {
+    start: true,
+    end: true,
+    asyncStart: 'result:SELECT 1',
+    asyncEnd: 'result:SELECT 1'
+  })
+})()

--- a/tests/arrow_this_property_args_cjs/mod.js
+++ b/tests/arrow_this_property_args_cjs/mod.js
@@ -1,0 +1,13 @@
+'use strict'
+
+// Arrow function assigned to `this` inside a constructor, with arguments.
+// Without the ArrowFunctionExpression → FunctionExpression conversion,
+// `arguments` inside the wrapper resolves to the constructor's arguments
+// (the opts object) rather than the actual call-site arguments (sql).
+function Connection (opts) {
+  this._query = async (sql) => {
+    return sql
+  }
+}
+
+module.exports = { Connection }

--- a/tests/arrow_this_property_args_cjs/test.js
+++ b/tests/arrow_this_property_args_cjs/test.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const { Connection } = require('./instrumented.js')
+const { assert, getContext } = require('../common/preamble.js')
+const context = getContext('orchestrion:undici:Connection_query_args')
+
+// Without the ArrowFunctionExpression → FunctionExpression fix, `sql` would
+// resolve to the constructor's opts argument rather than 'SELECT 1'.
+;(async () => {
+  const conn = new Connection({ host: 'localhost' })
+  const result = await conn._query('SELECT 1')
+  assert.strictEqual(result, 'SELECT 1')
+  assert.deepStrictEqual(context, {
+    start: true,
+    end: true,
+    asyncStart: 'SELECT 1',
+    asyncEnd: 'SELECT 1'
+  })
+})()

--- a/tests/instance_method_subclass_cjs/mod.js
+++ b/tests/instance_method_subclass_cjs/mod.js
@@ -1,7 +1,11 @@
+const assert = require('node:assert')
+
 class Base {}
 
 class Undici extends Base {
-  async fetch (url) {
+  async fetch (url, tag) {
+    assert.strictEqual(url, 'https://example.com')
+    assert.strictEqual(tag, 'mutated')
     return 42
   }
 }

--- a/tests/instance_method_subclass_cjs/test.js
+++ b/tests/instance_method_subclass_cjs/test.js
@@ -1,9 +1,20 @@
 const { Undici } = require('./instrumented.js')
 const { assert, getContext } = require('../common/preamble.js')
-const context = getContext('orchestrion:undici:Base_fetch');
-(async () => {
+const { tracingChannel } = require('node:diagnostics_channel')
+
+const context = getContext('orchestrion:undici:Base_fetch')
+
+// Mutate the second argument in the start channel subscriber
+tracingChannel('orchestrion:undici:Base_fetch').subscribe({
+  start (message) {
+    message.arguments[1] = 'mutated'
+  }
+})
+
+;(async () => {
   const undici = new Undici()
-  const result = await undici.fetch('https://example.com')
+  assert.strictEqual(undici.fetch.length, 2)
+  const result = await undici.fetch('https://example.com', 'original')
   assert.strictEqual(result, 42)
   assert.deepStrictEqual(context, {
     start: true,

--- a/tests/tests.test.mjs
+++ b/tests/tests.test.mjs
@@ -589,3 +589,15 @@ describe('arrow_this_property_args_cjs', () => {
     ])
   })
 })
+
+describe('arrow_this_binding_cjs', () => {
+  test('preserves lexical this and call-site arguments in wrapped arrow function', () => {
+    runTest('arrow_this_binding_cjs', [
+      {
+        channelName: 'Connection_query_this',
+        module: { name: TEST_MODULE_NAME, versionRange: '>=0.0.1', filePath: TEST_MODULE_PATH },
+        functionQuery: { objectName: 'this', propertyName: '_query', kind: 'Async' },
+      },
+    ])
+  })
+})

--- a/tests/tests.test.mjs
+++ b/tests/tests.test.mjs
@@ -565,3 +565,27 @@ describe('object_property_named_cjs', () => {
     ])
   })
 })
+
+describe('arrow_expr_args_cjs', () => {
+  test('correctly forwards call-site arguments when wrapping an arrow function via expressionName', () => {
+    runTest('arrow_expr_args_cjs', [
+      {
+        channelName: 'fetch_arrow_args',
+        module: { name: TEST_MODULE_NAME, versionRange: '>=0.0.1', filePath: TEST_MODULE_PATH },
+        functionQuery: { expressionName: 'fetch', kind: 'Async' },
+      },
+    ])
+  })
+})
+
+describe('arrow_this_property_args_cjs', () => {
+  test('correctly forwards call-site arguments when wrapping a this-assigned arrow function', () => {
+    runTest('arrow_this_property_args_cjs', [
+      {
+        channelName: 'Connection_query_args',
+        module: { name: TEST_MODULE_NAME, versionRange: '>=0.0.1', filePath: TEST_MODULE_PATH },
+        functionQuery: { objectName: 'this', propertyName: '_query', kind: 'Async' },
+      },
+    ])
+  })
+})


### PR DESCRIPTION
What does this PR do?                                                                                          
                                                                                                                 
  Fixes how the rewriter handles arrow function arguments. Arrow functions have no own arguments binding — they  
  inherit it from the enclosing scope. The generated wrapper preamble previously used arguments directly, which  
  resolved to the wrong scope for arrow functions. This caused silent data corruption (wrong arguments forwarded)
   or hard crashes in ESM (ReferenceError: arguments is not defined).                                            
                                                                                                                
  Approach
                                                                                                                 
  The initial approach was to convert ArrowFunctionExpression nodes to FunctionExpression before wrapping, giving
   the wrapper its own arguments. However this breaks lexical this for code that relies on it — arrow functions  
  capture this from the enclosing scope, and converting the node type changes that binding.                      
                                                                                                                 
  The next attempt used rest parameters (...__apm$args) on arrow functions only, keeping other function types    
  unchanged. This preserved this but introduced inconsistency between arrow and non-arrow code paths, and dropped
   the function's .length to 0.                                                                                  
                                                                                                                 
  The final approach replaces params on all function types with numbered placeholders (__apm$arg0, __apm$arg1,   
  ...__apm$args) via a shared wrapParams helper. The preamble reconstructs all arguments into __apm$arguments    
  from the placeholders. This:                                                                                   
                                                                                                                 
  - Preserves lexical this — the outer function type is never changed                                           
  - Preserves .length — numbered placeholders count toward function length, unlike a plain rest element
  - Works uniformly across all function types — one code path for arrow functions, regular functions, class      
  methods, and constructors                                                                                      
                                                                                                                 
  For constructors in classes that extend another class, apply(null, ...) is used instead of apply(this, ...)    
  because this can't be accessed before super() has been called.                                                 
                                                                                                                 
  For traceInstanceMethod, the original method's params aren't known at instrumentation time (the method is      
  assigned dynamically at runtime), so .length is restored via Object.defineProperty after capturing the         
  original.                                                                                                      
                                                                                                                 
  Relation to #58                                                                                               
                                                                                                                 
  Directly motivated by #58 (objectName+propertyName), which targets arrow functions assigned inside constructors
   — without this fix, #58's selector correctly finds and rewrites those functions but the instrumentation       
  silently misbehaves at runtime. However the fix is broader — any query type targeting an arrow function        
  (expressionName included) had the same broken arguments binding.    