### PR TITLE
add auto function kind for dynamic return value mechanisms

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ export interface TransformOutput {
 /**
  * The kind of function
  */
-export type FunctionKind = "Sync" | "Async" | "Callback";
+export type FunctionKind = "Sync" | "Async" | "Callback" | "Auto";
 
 /**
  * Describes which function to instrument

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -204,6 +204,7 @@ class Transformer {
 
     switch (kind) {
       case 'Async': return 'tracePromise'
+      case 'Auto': return 'traceAuto'
       case 'Callback': return 'traceCallback'
       case 'Sync': return 'traceSync'
       default: return 'traceSync'

--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -80,6 +80,7 @@ const transforms = module.exports = {
   traceCallback: traceAny,
   tracePromise: traceAny,
   traceSync: traceAny,
+  traceAuto: traceAny,
 }
 
 /**
@@ -247,6 +248,7 @@ function wrap (state, node, program) {
   if (operator === 'traceCallback') wrapper = wrapCallback(state, node)
   if (operator === 'tracePromise') wrapper = wrapPromise(state, node, program)
   if (operator === 'traceSync') wrapper = wrapSync(state, node, program)
+  if (operator === 'traceAuto') wrapper = wrapAuto(state, node, program)
 
   const args = (node.params || [])
     .filter(param => param.type !== 'RestElement' && param.type !== 'AssignmentPattern')
@@ -344,6 +346,48 @@ function wrapSuper (_state, node) {
   if (members.size > 0) {
     node.body.body.unshift(parse('const __apm$super = {}').body[0])
   }
+}
+
+/**
+ * Builds a composite wrapper AST that detects at runtime whether to use callback
+ * or promise tracing: if the argument at `callbackIndex` is a function, the
+ * callback path is taken; otherwise the promise path is used as the fallback.
+ *
+ * @param {object} state
+ * @param {import('estree').Node} node
+ * @param {import('estree').Program} program
+ * @returns {import('estree').Program} Parsed wrapper function program.
+ */
+function wrapAuto (state, node, program) {
+  const cbWrapperAST = wrapCallback(state, node)
+  const promiseWrapperAST = wrapPromise(state, node, program)
+
+  const [
+    getCbArg,
+    checkHasSubscribers,
+    defineWrappedCb,
+    checkCbIsFunction,
+    spliceCbArg,
+    runStores,
+  ] = cbWrapperAST.body[0].body.body
+
+  const fallbackToPromise = {
+    type: 'IfStatement',
+    test: checkCbIsFunction.test,
+    consequent: { type: 'BlockStatement', body: promiseWrapperAST.body[0].body.body },
+    alternate: null,
+  }
+
+  cbWrapperAST.body[0].body.body = [
+    getCbArg,
+    fallbackToPromise,
+    checkHasSubscribers,
+    defineWrappedCb,
+    spliceCbArg,
+    runStores,
+  ]
+
+  return cbWrapperAST
 }
 
 /**

--- a/tests/callback_promise_sync_cjs/mod.js
+++ b/tests/callback_promise_sync_cjs/mod.js
@@ -1,0 +1,11 @@
+function fetch (url, callback) {
+  if (typeof callback === 'function') {
+    process.nextTick(() => callback(null, 42))
+  } else if (url === 'async') {
+    return Promise.resolve(42)
+  } else {
+    return 42
+  }
+}
+
+module.exports = { fetch }

--- a/tests/callback_promise_sync_cjs/test.js
+++ b/tests/callback_promise_sync_cjs/test.js
@@ -1,0 +1,42 @@
+const { fetch } = require('./instrumented.js')
+const { assert, getContext } = require('../common/preamble.js')
+const context = getContext('orchestrion:undici:fetch.auto')
+
+function resetContext () {
+  for (const key of Object.keys(context)) delete context[key]
+}
+
+;(async () => {
+  // Callback path: last arg is a function → callback tracing
+  await new Promise((resolve, reject) => {
+    fetch('sync', (err, val) => {
+      if (err) reject(err)
+      else resolve(val)
+    })
+  })
+  assert.deepStrictEqual(context, {
+    start: true,
+    end: true,
+    asyncStart: 42,
+    asyncEnd: 42,
+  })
+  resetContext()
+
+  // Promise path: no callback, returns a thenable → asyncStart/asyncEnd fired on settlement
+  await fetch('async')
+  assert.deepStrictEqual(context, {
+    start: true,
+    end: true,
+    asyncStart: 42,
+    asyncEnd: 42,
+  })
+  resetContext()
+
+  // Sync path: no callback, returns a plain value → result captured in end, no async events
+  const result = fetch('sync')
+  assert.strictEqual(result, 42)
+  assert.deepStrictEqual(context, {
+    start: true,
+    end: 42,
+  })
+})()

--- a/tests/tests.test.mjs
+++ b/tests/tests.test.mjs
@@ -297,6 +297,18 @@ describe('callback_cjs', () => {
   })
 })
 
+describe('callback_promise_sync_cjs', () => {
+  test('instruments function covering callback, promise, and sync paths', () => {
+    runTest('callback_promise_sync_cjs', [
+      {
+        channelName: 'fetch.auto',
+        module: { name: TEST_MODULE_NAME, versionRange: '>=0.0.1', filePath: TEST_MODULE_PATH },
+        functionQuery: { functionName: 'fetch', kind: 'Auto' },
+      },
+    ])
+  })
+})
+
 describe('instance_method_subclass_cjs', () => {
   test('instruments inherited method via constructor patching on subclass', () => {
     runTest('instance_method_subclass_cjs', [


### PR DESCRIPTION
Not all functions have a fixed return value mechanism. Some functions can take a callback or return a promise, or return a promise or sync, etc. In static cases it's better to be explicit for more optimal code, but in cases where multiple mechanisms are supported it makes sense to let the code detect it at runtime.