### PR TITLE
update instance method test to use another file for subclass

### DIFF
--- a/tests/instance_method_subclass_cjs/mod.js
+++ b/tests/instance_method_subclass_cjs/mod.js
@@ -1,13 +1,3 @@
-const assert = require('node:assert')
-
 class Base {}
 
-class Undici extends Base {
-  async fetch (url, tag) {
-    assert.strictEqual(url, 'https://example.com')
-    assert.strictEqual(tag, 'mutated')
-    return 42
-  }
-}
-
-module.exports = { Undici }
+module.exports = { Base }

--- a/tests/instance_method_subclass_cjs/subclass.js
+++ b/tests/instance_method_subclass_cjs/subclass.js
@@ -1,0 +1,12 @@
+const assert = require('node:assert')
+const { Base } = require('./instrumented.js')
+
+class Undici extends Base {
+  async fetch (url, tag) {
+    assert.strictEqual(url, 'https://example.com')
+    assert.strictEqual(tag, 'mutated')
+    return 42
+  }
+}
+
+module.exports = { Undici }

--- a/tests/instance_method_subclass_cjs/test.js
+++ b/tests/instance_method_subclass_cjs/test.js
@@ -1,4 +1,4 @@
-const { Undici } = require('./instrumented.js')
+const { Undici } = require('./subclass.js')
 const { assert, getContext } = require('../common/preamble.js')
 const { tracingChannel } = require('node:diagnostics_channel')
 


### PR DESCRIPTION
The intended use case of patching instance methods is for when that method is on a subclass that is not reachable, so the test is more accurate with a separate file for the base class and subclass.