### PR TITLE
fix: preserve arguments.length for non-arrow wrapped functions

### DIFF
--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -142,6 +142,16 @@ function traceFunction (state, node, program) {
   (!methodName && !privateMethodName && !functionName && !expressionName)
   const type = isConstructor ? 'ArrowFunctionExpression' : 'FunctionExpression'
   const params = node.params
+  // Arrow outer wrappers have no own `arguments` object (and ESM top-level
+  // arrows have no enclosing one either), so we cannot read call arity from
+  // `arguments` there and must rebuild `__apm$arguments` from numbered
+  // placeholders. Non-arrow outer wrappers do have their own `arguments`,
+  // which is the only source of truth for real caller arity — so we keep the
+  // author's original param list and materialize `arguments` via
+  // `Array.prototype.slice.call(arguments)` in the preamble. Rebuilding from
+  // named placeholders would silently break functions that dispatch on
+  // `arguments.length` (e.g. graphql's `execute(argsOrSchema, ...)`).
+  const isArrowOuter = node.type === 'ArrowFunctionExpression'
 
   node.body = wrap(state, {
     type,
@@ -150,9 +160,9 @@ function traceFunction (state, node, program) {
     async: node.async,
     expression: false,
     generator: node.generator,
-  }, program)
+  }, program, isArrowOuter)
 
-  node.params = wrapParams(params)
+  if (isArrowOuter) node.params = wrapParams(params)
 
   // The original function no longer contains any calls to `await` or `yield` as
   // the function body is copied to the internal wrapped function, so we set
@@ -238,9 +248,15 @@ function traceInstanceMethod (state, node, program) {
  * @param {object} state
  * @param {import('estree').Node} node - The original function (or identifier for instance methods).
  * @param {import('estree').Program} program
+ * @param {boolean} [isArrowOuter=false] - Whether the outer wrapper is an arrow
+ *   function. Arrow outers cannot read their own `arguments`, so we rebuild
+ *   `__apm$arguments` from numbered placeholders. Non-arrow outers materialize
+ *   `arguments` via `Array.prototype.slice.call(arguments)`, preserving real
+ *   caller arity so wrapped code that dispatches on `arguments.length` keeps
+ *   working.
  * @returns {import('estree').BlockStatement['body']}
  */
-function wrap (state, node, program) {
+function wrap (state, node, program, isArrowOuter = false) {
   const { operator, moduleVersion } = state
 
   let wrapper
@@ -250,14 +266,20 @@ function wrap (state, node, program) {
   if (operator === 'traceSync') wrapper = wrapSync(state, node, program)
   if (operator === 'traceAuto') wrapper = wrapAuto(state, node, program)
 
-  const args = (node.params || [])
-    .filter(param => param.type !== 'RestElement' && param.type !== 'AssignmentPattern')
-    .map((_, i) => `__apm$arg${i}`).concat('...__apm$args').join(', ')
+  let argsLiteral
+  if (isArrowOuter) {
+    const args = (node.params || [])
+      .filter(param => param.type !== 'RestElement' && param.type !== 'AssignmentPattern')
+      .map((_, i) => `__apm$arg${i}`).concat('...__apm$args').join(', ')
+    argsLiteral = `[${args}]`
+  } else {
+    argsLiteral = 'Array.prototype.slice.call(arguments)'
+  }
 
   const block = wrapper.body[0].body // Extract only block statement of function body.
   const common = parse(node.type === 'ArrowFunctionExpression'
     ? `
-    const __apm$arguments = [${args}];
+    const __apm$arguments = ${argsLiteral};
     const __apm$ctx = {
       arguments: __apm$arguments,
       moduleVersion: ${JSON.stringify(moduleVersion)}
@@ -268,7 +290,7 @@ function wrap (state, node, program) {
     };
   `
     : `
-    const __apm$arguments = [${args}];
+    const __apm$arguments = ${argsLiteral};
     const __apm$ctx = {
       arguments: __apm$arguments,
       self: this,

--- a/tests/arguments_length_dispatch_cjs/mod.js
+++ b/tests/arguments_length_dispatch_cjs/mod.js
@@ -1,0 +1,17 @@
+'use strict'
+
+// Regression for the graphql-style overload pattern. `execute` dispatches on
+// `arguments.length` to choose between an options-object form and a positional
+// form. Without `Array.prototype.slice.call(arguments)` in the non-arrow
+// preamble, the rebuilt args array was padded with undefined up to the
+// declared arity, so `arguments.length` inside the moved-out body was always
+// the declared arity (8) instead of the caller's real arity.
+function execute (argsOrSchema, document, rootValue, contextValue,
+  variableValues, operationName, fieldResolver, typeResolver) {
+  if (arguments.length === 1) {
+    return 'object-form:' + argsOrSchema.marker
+  }
+  return 'positional-form:' + argsOrSchema + ',' + document
+}
+
+module.exports = { execute }

--- a/tests/arguments_length_dispatch_cjs/test.js
+++ b/tests/arguments_length_dispatch_cjs/test.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const { execute } = require('./instrumented.js')
+const { assert, getContext } = require('../common/preamble.js')
+const context = getContext('orchestrion:undici:execute')
+
+// The outer wrapper must still expose the author's declared arity.
+assert.strictEqual(execute.length, 8)
+
+// Single-arg call must take the object-form branch. Before the slice-based
+// preamble, `arguments.length` inside the wrapped body was always 8, so this
+// call silently took the positional branch and crashed on `undefined.marker`.
+assert.strictEqual(execute({ marker: 'x' }), 'object-form:x')
+
+// Multi-arg call must take the positional branch.
+assert.strictEqual(execute('schema', 'doc'), 'positional-form:schema,doc')
+
+// Last-call context reflects the positional branch's return value.
+assert.deepStrictEqual(context, {
+  start: true,
+  end: 'positional-form:schema,doc'
+})

--- a/tests/tests.test.mjs
+++ b/tests/tests.test.mjs
@@ -64,6 +64,18 @@ describe('arguments_mutation', () => {
   })
 })
 
+describe('arguments_length_dispatch_cjs', () => {
+  test('preserves caller arity inside wrapped function that dispatches on arguments.length', () => {
+    runTest('arguments_length_dispatch_cjs', [
+      {
+        channelName: 'execute',
+        module: { name: TEST_MODULE_NAME, versionRange: '>=0.0.1', filePath: TEST_MODULE_PATH },
+        functionQuery: { functionName: 'execute', kind: 'Sync' },
+      },
+    ])
+  })
+})
+
 describe('class_expression_cjs', () => {
   test('instruments async class method on class expression', () => {
     runTest('class_expression_cjs', [


### PR DESCRIPTION
## Summary

PR #60 replaced every wrapped function's params with numbered placeholders (`__apm$arg0…N, ...__apm$args`) and rebuilt `__apm$arguments` from them. That rebuild pads unfilled named slots with `undefined`, so the array handed to `.apply` always has the declared arity rather than the caller's real arity. Wrapped functions that dispatch on `arguments.length` silently take the wrong branch on calls with fewer args than params.

Concrete breakage: graphql's `execute(argsOrSchema, document, rootValue, contextValue, variableValues, operationName, fieldResolver, typeResolver)` uses the classic dual-mode pattern

```js
return arguments.length === 1
  ? executeImpl(argsOrSchema)                              // object form
  : executeImpl({ schema: argsOrSchema, document, ... })   // positional form
```

After the PR #60 rewrite, `arguments.length` inside the moved-out body is always 8 regardless of what the caller passed. `graphql.execute({ schema, source })` now takes the positional branch, hands `undefined` to `executeImpl` as `document`, and throws `"Must provide document."` before any user code runs. Any function with a similar overload (lodash-style options-vs-positional dispatch, optional-trailing-arg detection, variadics that distinguish zero args from one explicit `undefined`) breaks the same way.

## Fix

Two templates, split on whether the outer wrapper is an arrow:

- **Arrow outer** — keep PR #60's numbered-placeholder rebuild unchanged. Arrows have no own `arguments` (and ESM top-level arrows have no enclosing one), so they can't read real arity from `arguments`. The numbered-placeholder rebuild is the only approach that works uniformly for arrows in every context — nested in a function, at ESM top level, or at CJS top level. This is exactly the correctness guarantee PR #60 was built to deliver, and it's preserved here.
- **Non-arrow outer (regular function, method, constructor)** — leave the author's original params on the outer wrapper (preserves `.length`) and materialize `arguments` via `Array.prototype.slice.call(arguments)` in the preamble (preserves real caller arity). Non-arrow outer wrappers always have their own `arguments` object regardless of surrounding scope or module type, so reading it is safe in every case where this path is taken.

The `Array.prototype.X.call(args-like)` idiom matches existing usage elsewhere in the wrapper code (`Array.prototype.at.call`, `Array.prototype.splice.call`).

## Why not unify the two templates

This re-introduces two templates, which a previous iteration of PR #60 was moved away from. Two things have changed:

1. The earlier "two-template" iteration dropped `.length` to 0 on the arrow side because it used a bare `...rest` param. This PR keeps PR #60's numbered-placeholder approach for arrows, so `.length` stays correct on both paths.
2. The single-template design PR #60 landed on has a correctness bug for `arguments.length`-dispatching functions that cannot be fixed without either (a) reading `arguments` in the outer wrapper, which re-opens PR #60's arrow and ESM bugs, or (b) detecting unfilled params at runtime, which is not possible in JS (`f(undefined)` is indistinguishable from `f()` once a param binding is established). Splitting on wrapper shape is the only way both correctness properties hold simultaneously.

## Test plan

- [x] New test: `tests/arguments_length_dispatch_cjs/` — regular function that dispatches on `arguments.length`, called with 1 arg (expects object-form branch) and with 2 args (expects positional branch), and asserts `fn.length` still equals the declared arity.
- [x] Full existing suite (42/42) still passes — arrow-path tests (`arrow_expr_args_cjs`, `arrow_this_binding_cjs`, `arrow_this_property_args_cjs`, `object_property_this_cjs`, `object_property_named_cjs`) confirm the PR #60 fast path is unchanged.
- [x] `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)