### PR TITLE
feat: Support matching Regex `filepath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,15 @@ type FunctionQuery =
 
 ```ts
 type ModuleMatcher = {
-    name: string; // Module name
-    versionRange: string; // Matching semver range
-    filePath: string; // Relative Unix-style path to the file from the module root (e.g. "lib/index.js")
+    /** Module name */
+    name: string; 
+    /** Matching semver range */
+    versionRange: string;
+    /** 
+     * Relative Unix-style path to the file from the module root (e.g. "lib/index.js") 
+     * Or a regular expression to test against the Unix-style path.
+     */
+    filePath: string | RegExp;
 };
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -73,7 +73,7 @@ export interface ModuleMatcher {
     /**
      * The path of the file you want to match from the module root
      */
-    filePath: string;
+    filePath: string | RegExp;
 }
 
 /**

--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -61,7 +61,7 @@ class InstrumentationMatcher {
 
     const configs = this.#configs.filter(({ module: mod }) =>
       mod.name === moduleName &&
-      mod.filePath === filePath &&
+      (typeof mod.filePath === 'string' ? mod.filePath === filePath : mod.filePath.test(filePath)) &&
       semifies(version, mod.versionRange)
     )
 

--- a/tests/tests.test.mjs
+++ b/tests/tests.test.mjs
@@ -13,6 +13,7 @@ const TEST_MODULE_NAME = 'undici'
 const TEST_MODULE_VERSION = '0.0.1'
 const TEST_MODULE_PATH = 'index.mjs'
 const WINDOWS_MODULE_PATH = 'lib/index.mjs'
+const WINDOWS_MODULE_REGEX = /lib\/index\.m?js/
 
 function runTest (testName, configs, { mjs = false, filePath = TEST_MODULE_PATH, dcModule, customTransforms = {} } = {}) {
   const ext = mjs ? 'mjs' : 'js'
@@ -303,6 +304,18 @@ describe('windows_path', () => {
       {
         channelName: 'fetch_decl',
         module: { name: TEST_MODULE_NAME, versionRange: '>=0.0.1', filePath: WINDOWS_MODULE_PATH },
+        functionQuery: { functionName: 'fetch', kind: 'Async' },
+      },
+    ], { filePath: 'lib\\index.mjs' })
+  })
+})
+
+describe('windows_path_regex', () => {
+  test('instruments with windows-style file path matching regex', () => {
+    runTest('windows_path', [
+      {
+        channelName: 'fetch_decl',
+        module: { name: TEST_MODULE_NAME, versionRange: '>=0.0.1', filePath: WINDOWS_MODULE_REGEX },
         functionQuery: { functionName: 'fetch', kind: 'Async' },
       },
     ], { filePath: 'lib\\index.mjs' })


### PR DESCRIPTION
Some libraries use bunders for their output and in some cases we end up needing to inject instrumentation into files that contain hashes in their names like `index-sG3fGv.js`. This small change allows matching with a regular expression. Windows path normalisation has already occurred at before matching which simplifies regexes.