### PR TITLE
feat: Expose Transformer `moduleName` and `filePath`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -111,6 +111,13 @@ export class Transformer {
   get moduleName(): string;
 
   /**
+   * The relative file path within the npm package being instrumented.
+   *
+   * @returns {string}
+   */
+  get filePath(): string;
+
+  /**
    * Transform JavaScript code and optionally sourcemap.
    *
    * # Errors

--- a/index.d.ts
+++ b/index.d.ts
@@ -104,6 +104,12 @@ export class InstrumentationMatcher {
 export class Transformer {
   private constructor();
   free(): void;
+
+  /**
+   * The name of the module to transform.
+   */
+  get moduleName(): string;
+
   /**
    * Transform JavaScript code and optionally sourcemap.
    *

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -41,6 +41,11 @@ class Transformer {
   /** No-op — freeing resources is not needed for the JavaScript implementation. */
   free () {}
 
+  /** The npm package name being instrumented. */
+  get moduleName () {
+    return this.#moduleName
+  }
+
   /**
    * Instruments `code` by injecting diagnostics_channel tracing around the
    * target functions defined by this transformer's configs.

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -51,6 +51,15 @@ class Transformer {
   }
 
   /**
+   * The relative file path within the npm package being instrumented.
+   *
+   * @returns {string}
+   */
+  get filePath () {
+    return this.#filePath
+  }
+
+  /**
    * Instruments `code` by injecting diagnostics_channel tracing around the
    * target functions defined by this transformer's configs.
    *

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -41,7 +41,11 @@ class Transformer {
   /** No-op — freeing resources is not needed for the JavaScript implementation. */
   free () {}
 
-  /** The npm package name being instrumented. */
+  /**
+   * The npm package name being instrumented.
+   *
+   * @returns {string}
+   */
   get moduleName () {
     return this.#moduleName
   }


### PR DESCRIPTION
For dianostics we would like to track modules which have been transformed. This is easier to do if we can see which module a transformer matches!