### PR TITLE
fix: Pass through sourcemaps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -123,5 +123,5 @@ export class Transformer {
    * # Errors
    * Returns an error if the transformation fails to find injection points.
    */
-  transform(code: string | Buffer, moduleType: ModuleType, sourcemap?: string | null): TransformOutput;
+  transform(code: string | Buffer, moduleType: ModuleType, sourcemap?: string | object | null): TransformOutput;
 }

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -134,12 +134,11 @@ class Transformer {
     }
 
     if (ast) {
-      SourceMapConsumer ??= require('source-map').SourceMapConsumer
       SourceMapGenerator ??= require('source-map').SourceMapGenerator
 
       const file = `${this.#moduleName}/${this.#filePath}`
-      const sourceMapInput = sourcemap ? new SourceMapConsumer(sourcemap) : { file }
-      const sourceMap = new SourceMapGenerator(sourceMapInput)
+      const sourceMap = new SourceMapGenerator({ file })
+
       const code = generate(ast, { sourceMap })
       const map = sourceMap.toString()
 

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -5,7 +5,6 @@ const { parse } = require('meriyah')
 const { generate } = require('astring')
 const transforms = require('./transforms')
 
-let SourceMapConsumer
 let SourceMapGenerator
 
 /**

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -5,6 +5,7 @@ const { parse } = require('meriyah')
 const { generate } = require('astring')
 const transforms = require('./transforms')
 
+let SourceMapConsumer
 let SourceMapGenerator
 
 /**
@@ -133,13 +134,21 @@ class Transformer {
     }
 
     if (ast) {
+      SourceMapConsumer ??= require('source-map').SourceMapConsumer
       SourceMapGenerator ??= require('source-map').SourceMapGenerator
 
       const file = `${this.#moduleName}/${this.#filePath}`
-      const sourceMap = new SourceMapGenerator({ file })
+      let generator
+      if (sourcemap) {
+        const consumer = new SourceMapConsumer(sourcemap)
+        consumer.file = file
+        generator = SourceMapGenerator.fromSourceMap(consumer)
+      } else {
+        generator = new SourceMapGenerator({ file })
+      }
 
-      const code = generate(ast, { sourceMap })
-      const map = sourceMap.toString()
+      const code = generate(ast, { sourceMap: generator })
+      const map = generator.toString()
 
       return { code, map }
     }

--- a/tests/tests.test.mjs
+++ b/tests/tests.test.mjs
@@ -516,6 +516,23 @@ describe('source_map', () => {
     assert.equal(original.line, originalReturnLine)
     assert.equal(original.column, originalReturnColumn)
   })
+
+  test('produces a valid sourcemap when an inputSourceMap is provided', () => {
+    const code = 'export class Undici { async fetch (url) { return 42; } }'
+    const inputSourceMap = { version: 3, sources: ['input.js'], mappings: 'AAAA', names: [] }
+
+    const instrumentor = create([
+      {
+        channelName: 'Undici:fetch',
+        module: { name: TEST_MODULE_NAME, versionRange: '>=0.0.1', filePath: TEST_MODULE_PATH },
+        functionQuery: { className: 'Undici', methodName: 'fetch', kind: 'Async' },
+      },
+    ])
+    const transformer = instrumentor.getTransformer(TEST_MODULE_NAME, TEST_MODULE_VERSION, TEST_MODULE_PATH)
+    const { map } = transformer.transform(code, 'esm', inputSourceMap)
+
+    assert.equal(JSON.parse(map).file, `${TEST_MODULE_NAME}/${TEST_MODULE_PATH}`)
+  })
 })
 
 describe('wrap_promise_non_promise', () => {


### PR DESCRIPTION
I was testing sourcemap pass through support and found an issue!

The added test case results in the following error:
```
✖ produces a valid sourcemap when an inputSourceMap is provided (0.819125ms)
  TypeError [Error]: Converting circular structure to JSON
      --> starting at object with constructor 'State'
      |     property 'mapping' -> object with constructor 'Object'
      --- property 'generated' closes the circle
      at JSON.stringify (<anonymous>)
      at SourceMapGenerator.SourceMapGenerator_validateMapping [as _validateMapping] (/orchestrion-js/node_modules/source-map/lib/source-map-generator.js:298:50)
      at SourceMapGenerator.SourceMapGenerator_addMapping [as addMapping] (/orchestrion-js/node_modules/source-map/lib/source-map-generator.js:110:12)
      at State.map (/orchestrion-js/node_modules/astring/dist/astring.js:1203:26)
      at State.writeAndMap (/orchestrion-js/node_modules/astring/dist/astring.js:1179:12)
      at Object.ClassDeclaration (/orchestrion-js/node_modules/astring/dist/astring.js:515:11)
      at Object.ExportNamedDeclaration (/orchestrion-js/node_modules/astring/dist/astring.js:625:34)
      at Object.Program (/orchestrion-js/node_modules/astring/dist/astring.js:234:27)
      at generate (/orchestrion-js/node_modules/astring/dist/astring.js:1250:29)
      at Transformer.transform (/orchestrion-js/lib/transformer.js:143:20)
```