### PR TITLE
feat: Remove unused `free()` methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -86,7 +86,6 @@ export type ModuleType = "esm" | "cjs" | "unknown";
  */
 export class InstrumentationMatcher {
   private constructor();
-  free(): void;
   /**
    * Get a transformer for the given module name, version and file path.
    * Returns `undefined` if no matching instrumentations are found.
@@ -103,8 +102,6 @@ export class InstrumentationMatcher {
  */
 export class Transformer {
   private constructor();
-  free(): void;
-
   /**
    * The name of the module to transform.
    */


### PR DESCRIPTION
These are only in the public API because they were required in the previous wasm version of this library.