### PR TITLE
chore: Fix release issue by pinning npm version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
-      # Install latest npm cli so we can publish via OIDC
-      - run: npm install -g npm@latest
+      # Install npm v11 so we can publish via OIDC
+      - run: npm install -g npm@11
       - run: npm install
       - run: npm publish --access public


### PR DESCRIPTION
Our last publish failed:
https://github.com/nodejs/orchestrion-js/actions/runs/29027300841/job/86150397111

This PR pins the npm version so publishing still works!