### PR TITLE
fix: Allow custom transforms to call default transforms

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,7 @@ export type KnownState = InstrumentationConfig & {
     /** The resolved operator name: a built-in (e.g. `'traceSync'`) or a custom transform name */
     operator: string;
     /** The merged transform map (built-ins plus `addTransform` overrides) used for dispatch */
-    transforms: Record<string, CustomTransform>;
+    transforms: Record<string, CustomTransform> & { defaults: Record<string, CustomTransform> };
     /** Counter of function nodes matched so far, used for `index`-based selection */
     functionIndex?: number;
 };

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -78,7 +78,7 @@ class Transformer {
     let aliases = {}
     let injectionCount = 0
 
-    const mergedTransforms = { ...transforms, ...this.#customTransforms }
+    const mergedTransforms = { ...transforms, ...this.#customTransforms, defaults: { ...transforms } }
 
     for (const config of this.#configs) {
       const { astQuery, functionQuery = {} } = config

--- a/tests/custom_transform_defaults_cjs/mod.js
+++ b/tests/custom_transform_defaults_cjs/mod.js
@@ -1,0 +1,5 @@
+function fetch (url) {
+  return 42
+}
+
+module.exports = { fetch }

--- a/tests/custom_transform_defaults_cjs/test.js
+++ b/tests/custom_transform_defaults_cjs/test.js
@@ -1,0 +1,5 @@
+const { fetch } = require('./instrumented.js')
+const assert = require('node:assert')
+
+assert.strictEqual(global.__defaultTransformCalled, true)
+assert.strictEqual(fetch('https://example.com'), 42)

--- a/tests/tests.test.mjs
+++ b/tests/tests.test.mjs
@@ -597,6 +597,39 @@ describe('custom_transform_override_cjs', () => {
   })
 })
 
+describe('custom_transform_defaults_cjs', () => {
+  test('custom transforms can call built-in transforms via state.transforms.defaults', () => {
+    runTest('custom_transform_defaults_cjs', [
+      {
+        channelName: 'fetch_defaults',
+        module: { name: TEST_MODULE_NAME, versionRange: '>=0.0.1', filePath: TEST_MODULE_PATH },
+        functionQuery: { functionName: 'fetch', kind: 'Sync' },
+      },
+    ], {
+      customTransforms: {
+        tracingChannelImport (state, node) {
+          state.transforms.defaults.tracingChannelImport(state, node)
+          node.body.unshift({
+            type: 'ExpressionStatement',
+            expression: {
+              type: 'AssignmentExpression',
+              operator: '=',
+              left: {
+                type: 'MemberExpression',
+                object: { type: 'Identifier', name: 'global' },
+                property: { type: 'Identifier', name: '__defaultTransformCalled' },
+                computed: false,
+                optional: false,
+              },
+              right: { type: 'Literal', value: true, raw: 'true' },
+            },
+          })
+        },
+      },
+    })
+  })
+})
+
 describe('buffer_input', () => {
   test('accepts a Buffer and produces the same output as a string', () => {
     const code = [


### PR DESCRIPTION
I forgot about this in my previous PR (#97) 🤦🏻‍♂️

This extra change allows custom transforms to call default transforms. This is especially useful if you want to call the transform you've overridden!

```ts
function customTracingChannelImport(state, program) {
  state.transforms.defaults.tracingChannelImport(state, program);

  // do other shenanigans...
}
```