### PR TITLE
fix: `meriyah` export map Nitro/Rollup issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/estree": "^1.0.8",
     "astring": "^1.9.0",
     "esquery": "^1.7.0",
-    "meriyah": "^6.1.4",
+    "meriyah": "^6.0.0",
     "semifies": "^1.0.0",
     "source-map": "^0.6.0"
   },


### PR DESCRIPTION
`meriyah` changed its export map for 6.1.0 and removed the `import` condition:

version | exports
-- | --
5.0.0 | {"import": "./dist/meriyah.esm.mjs", "require": "./dist/meriyah.cjs", ...}
6.0.0 | {"import": "./dist/meriyah.min.mjs", "require": "./dist/meriyah.cjs", ...}
6.1.0+ | {"module-sync": "./dist/meriyah.mjs", "require": "./dist/meriyah.cjs", "default": "./dist/meriyah.mjs"} — no plain "import" key

This causes issues with Nitro and/or the Rollup CommonJs plugin which fails to resolve the required files. The module then can't be found at runtime.

I opened a PR to add this back in meriyah:
- https://github.com/meriyah/meriyah/pull/585

However, they are a major ahead of us. Even if this gets merged we can't use it without dropping Node v18 support. @nodejs/orchestrion-js-maintainers does anyone else still need to support Node v18?

I also opened an issue for Nitro:
- https://github.com/nitrojs/nitro/issues/4456

This PR downgrades to a `meriyah` version which doesn't cause the issue. Hopefully we can revert this at some point or upgrade to v7?

